### PR TITLE
Updated deprecated IPython.core.display command

### DIFF
--- a/docs/00-xyz-sample-notebook.ipynb
+++ b/docs/00-xyz-sample-notebook.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from IPython.core.display import display, HTML\n",
+    "from IPython.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]
   },

--- a/{{ cookiecutter.repo_name }}/reference/easydata/notebooks.md
+++ b/{{ cookiecutter.repo_name }}/reference/easydata/notebooks.md
@@ -49,7 +49,7 @@ First up, if you're in a notebook, keyboard shortcuts can be found using the `Es
 #### Better display
 This cell makes your jupyter notebook use the full screen width. Put this as your first executable cell. You'll thank us.
 ```python
-from IPython.core.display import display, HTML
+from IPython.display import display, HTML
 display(HTML("<style>.container { width:100% !important; }</style>"))
 ```
 #### Autoreloading


### PR DESCRIPTION
- A deprecation warning is thrown if you use IPython.core.display. IPython.display is the new syntax.